### PR TITLE
update tests for resetting userGroupData

### DIFF
--- a/src/components/GroupStage.vue
+++ b/src/components/GroupStage.vue
@@ -56,12 +56,6 @@ export default {
             set(value) {
                 this.$store.commit('updateUserGroupData', value)
             }
-        },
-        // userGroupData() {
-        //     return this.$store.state.userGroupData
-        // },
-        ogGroupData() {
-            return this.$store.state.ogGroupData
         }
     },
     methods: {
@@ -77,8 +71,6 @@ export default {
 
         // Reset the groups to the default value
         resetGroupData() {
-            console.log('Reset to ogGroupData!');
-
             this.$store.commit('resetUserGroupData');
 
             localStorage.removeItem('userGroupData');

--- a/src/components/GroupStage.vue
+++ b/src/components/GroupStage.vue
@@ -80,10 +80,10 @@ export default {
             console.log('Reset to ogGroupData!');
 
             this.$store.commit('resetUserGroupData');
-            localStorage.removeItem('userGroupData');
-            this.updateRoundOneData();
 
-            console.log('reset should happen', this.userGroupData);
+            localStorage.removeItem('userGroupData');
+
+            this.updateRoundOneData();
         }
     }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -223,8 +223,6 @@ export default createStore({
       state.userGroupData = d;
     },
     resetUserGroupData: (state) => {
-      console.log('userGroupData', state.userGroupData)
-      console.log('ogGroupData', state.ogGroupData)
       state.userGroupData = JSON.parse(JSON.stringify(state.ogGroupData));
     },
     updateRoundOne: (state) => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -225,7 +225,7 @@ export default createStore({
     resetUserGroupData: (state) => {
       console.log('userGroupData', state.userGroupData)
       console.log('ogGroupData', state.ogGroupData)
-      state.userGroupData = state.ogGroupData;
+      state.userGroupData = JSON.parse(JSON.stringify(state.ogGroupData));
     },
     updateRoundOne: (state) => {
       // add correct teams to roundOne

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -223,6 +223,8 @@ export default createStore({
       state.userGroupData = d;
     },
     resetUserGroupData: (state) => {
+      console.log('userGroupData', state.userGroupData)
+      console.log('ogGroupData', state.ogGroupData)
       state.userGroupData = state.ogGroupData;
     },
     updateRoundOne: (state) => {


### PR DESCRIPTION
## Purpose
- add a reset button to reset the `userGroupData` back to the `ogGroupData`

## Notes
- to replicate the issue move some teams around in the group and click the "reset groups" button. in the console you'll see that both `userGroupData` and `ogGroupData` are the same which is not wanted. `ogGroupData` should never change.
- when localStorage is used as the `userGroupData` however the reset button works.
@mjweaver01 wondering if you could take a look